### PR TITLE
Fix Everyone Wins image path

### DIFF
--- a/index.html
+++ b/index.html
@@ -1404,7 +1404,7 @@
 				</div>
 
 				<div class="ecosystem-diagram">
-					<img src="drivemind_ecosystem_enhanced.png" alt="DriveMind Ecosystem - Everyone Wins" loading="lazy">
+					<img src="assets/drivemind_ecosystem_enhanced.png" alt="DriveMind Ecosystem - Everyone Wins" loading="lazy">
 				</div>
 
 				<div class="ecosystem-tagline">


### PR DESCRIPTION
## Summary
- correct `drivemind_ecosystem_enhanced.png` path in the Everyone Wins diagram

## Testing
- `w3m -dump file:///workspace/drivemind-landing/index.html | head -n 40`


------
https://chatgpt.com/codex/tasks/task_e_68716f2f3d008328b8dae1b75849ee1d