### PR TITLE
Add GDPR privacy policy page and footer link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1040,6 +1040,12 @@
 				font-size: 1rem;
 				margin-bottom: 20px;
 			}
+                        .footer-legal a {
+                                font-size: 0.875rem;
+                                color: #9CA3AF;
+                                text-decoration: underline;
+                        }
+
 
 			/* Responsive Design */
 			@media (max-width: 768px) {
@@ -1624,7 +1630,12 @@
 				<p class="footer-tagline">Decode Your Car. No Hardware Required.</p>
 				<div class="footer-dm">DM</div>
 			</div>
-		</footer>
+        <div class="footer-legal">
+                <a href="/privacy-policy" target="_blank" rel="noopener noreferrer">
+                        Privacy Policy
+                </a>
+        </div>
+</footer>
 
 		<script>
 			// Sticky header functionality

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy - DriveMind</title>
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="stylesheet" href="assets/index-DoFs5sed.css">
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 40px;
+            max-width: 800px;
+            margin: auto;
+            line-height: 1.6;
+        }
+    </style>
+</head>
+<body>
+<h1>📄 Privacy Policy for DriveMind</h1>
+<p><strong>Effective Date:</strong> July 11, 2025<br>
+<strong>Last Updated:</strong> July 11, 2025</p>
+<p>Welcome to DriveMind! Your privacy is important to us. This Privacy Policy explains how we collect, use, and protect your information when you use our services — including the DriveMind app, website (https://drivemind.app), and chatbot assistant.</p>
+<hr>
+<h2>🔍 1. What We Collect</h2>
+<p>We collect only the information we need to help you:</p>
+<table>
+<thead>
+<tr><th>Data Type</th><th>Why We Collect It</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>Name</strong></td><td>So we know who you are</td></tr>
+<tr><td><strong>Email address</strong></td><td>To send updates, diagnostics, or support replies</td></tr>
+<tr><td><strong>Vehicle info</strong></td><td>To help you understand warning lights, codes, and TSBs</td></tr>
+<tr><td><strong>Chat interactions</strong></td><td>To improve app performance and provide relevant answers</td></tr>
+<tr><td><strong>Device data</strong></td><td>Basic info like OS type and browser (for security/debugging)</td></tr>
+</tbody>
+</table>
+<p>We don’t collect sensitive information like credit card numbers or geolocation unless you opt in.</p>
+<hr>
+<h2>📲 2. How We Use Your Information</h2>
+<p>We use your info to:</p>
+<ul>
+<li>Help you interpret vehicle issues</li>
+<li>Send app-related updates or replies</li>
+<li>Improve the chatbot and user experience</li>
+<li>Build new features responsibly</li>
+</ul>
+<hr>
+<h2>🛡️ 3. How We Protect Your Data</h2>
+<p>We use modern encryption, HTTPS security, and limit internal access to your data. Your information will <strong>never</strong> be sold, rented, or shared with third parties for marketing.</p>
+<hr>
+<h2>🇪🇺 4. GDPR Compliance (EU Users)</h2>
+<p>If you’re in the European Union, you have these rights:</p>
+<ul>
+<li><strong>Right to Access</strong>: Request a copy of your data</li>
+<li><strong>Right to Rectify</strong>: Fix any errors in your data</li>
+<li><strong>Right to Erase</strong>: Delete your data at any time</li>
+<li><strong>Right to Restrict/Object</strong>: Limit how we process your data</li>
+<li><strong>Right to Portability</strong>: Request your data in a portable format</li>
+</ul>
+<p>To exercise these rights, email us at: <a href="mailto:support@drivemind.app">support@drivemind.app</a></p>
+<p>We process your data based on:</p>
+<ul>
+<li>Your <strong>consent</strong> (when signing up or chatting)</li>
+<li>Our <strong>legitimate interest</strong> to run the app</li>
+<li>Legal compliance (e.g. debugging or fraud prevention)</li>
+</ul>
+<hr>
+<h2>🌎 5. Where Your Data Is Stored</h2>
+<p>Your data may be stored securely in the United States and/or in EU-compliant cloud providers. We work only with trusted services like Aidbase, Supabase, or Google Cloud.</p>
+<hr>
+<h2>📬 6. Communications</h2>
+<p>If you join the waitlist, submit a ticket, or engage with our chatbot, you may receive:</p>
+<ul>
+<li>Confirmation emails</li>
+<li>Important updates</li>
+<li>Opt-in product announcements</li>
+</ul>
+<p>You can unsubscribe at any time.</p>
+<hr>
+<h2>🧼 7. Data Retention</h2>
+<p>We keep your data only as long as needed to provide service, or until you ask us to delete it.</p>
+<hr>
+<h2>🔗 8. Third-Party Tools</h2>
+<p>We may use third-party platforms like:</p>
+<ul>
+<li><strong>Aidbase</strong> – for live chat and support tickets</li>
+<li><strong>Google Analytics</strong> – for anonymized usage stats</li>
+<li><strong>Mailgun / Brevo</strong> – for emails or waitlist management</li>
+</ul>
+<p>These services are GDPR-aligned and follow strict data practices.</p>
+<hr>
+<h2>📘 9. Cookies</h2>
+<p>We use essential and performance cookies to make the website work better. No creepy tracking. You’ll be notified and can opt out where applicable.</p>
+<hr>
+<h2>📝 10. Changes to This Policy</h2>
+<p>We may update this policy to reflect changes. If so, we’ll update the "Last Updated" date and notify users as needed.</p>
+<hr>
+<h2>📮 11. Contact Us</h2>
+<p><strong>DriveMind Support</strong><br>
+📧 <a href="mailto:support@drivemind.app">support@drivemind.app</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add footer Privacy Policy link
- style the link with neutral text color and underline
- create Privacy Policy page at `/privacy-policy`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6871b489a1b08328a3d46fc81acd0a78