### PR TITLE
Connect waitlist form to Make webhook

### DIFF
--- a/index.html
+++ b/index.html
@@ -1605,9 +1605,9 @@
 					Join the exclusive beta and help shape the future of car diagnostics. For our first 1,000 testers: Get lifetime Pro access — full features, forever, for free.
 				</p>
 
-				<form class="cta-form" id="betaForm">
-					<div class="form-group">
-						<input type="email" class="form-input" placeholder="Enter your email" required>
+                                <form class="cta-form" id="betaWaitlistForm">
+                                        <div class="form-group">
+                                                <input type="email" class="form-input" placeholder="Enter your email" required id="email" name="email">
 						<button type="submit" class="form-submit">Join Beta Waitlist</button>
 					</div>
 					<div class="form-success" id="formSuccess">
@@ -1671,37 +1671,23 @@
 			});
 
                         // Form submission
-                        document.getElementById('betaForm').addEventListener('submit', async function (e) {
-                                e.preventDefault();
+                        document.querySelector('#betaWaitlistForm').addEventListener('submit', async function (e) {
+                          e.preventDefault();
 
-                                const emailInput = this.querySelector('input[type="email"]');
-                                const email = emailInput.value;
+                          const email = document.querySelector('#email').value;
 
-                                const payload = {
-                                        source: 'DriveMind Beta Chatbot',
-                                        email: email,
-                                        timestamp: new Date().toISOString()
-                                };
+                          await fetch('https://hook.us2.make.com/bsg8xhduws6uynabp249kxpyudvp2dxb', {
+                            method: 'POST',
+                            headers: {
+                              'Content-Type': 'application/json'
+                            },
+                            body: JSON.stringify({
+                              email: email,
+                              submitted_at: new Date().toISOString()
+                            })
+                          });
 
-                                try {
-                                        const res = await fetch('https://api.drivemind.app/webhooks/aidbase-lead', {
-                                                method: 'POST',
-                                                headers: {
-                                                        'Content-Type': 'application/json'
-                                                },
-                                                body: JSON.stringify(payload)
-                                        });
-
-                                        if (res.ok) {
-                                                emailInput.value = '';
-                                                document.getElementById('formSuccess').style.display = 'block';
-                                                console.log('Lead sent to DriveMind webhook successfully.');
-                                        } else {
-                                                console.error('DriveMind webhook error:', await res.text());
-                                        }
-                                } catch (error) {
-                                        console.error('Failed to connect to DriveMind webhook:', error);
-                                }
+                          alert('✅ You\u2019re on the DriveMind waitlist! We\u2019ll be in touch soon.');
                         });
 
 			// Fade in animation on scroll


### PR DESCRIPTION
## Summary
- update the waitlist form to use `id="betaWaitlistForm"` and add `id="email"`
- post signups to the live Make.com webhook URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68733d0c6b2c832887a00eed7a699758